### PR TITLE
Feat: custom hook useScrollToTop 추가

### DIFF
--- a/src/components/IssueDetail/index.tsx
+++ b/src/components/IssueDetail/index.tsx
@@ -7,8 +7,10 @@ import {
 import Loading from "../common/Loading";
 import Error from "../common/Error";
 import { IssueDetailBox } from "./IssueDetail.styles";
+import useScrollToTop from "../../hooks/useScrollToTop";
 
 function IssueDetail() {
+  useScrollToTop();
   const { data, error, loading } = useIssueDetail();
   const fetchIssueDetail = useIssueDetailDispatch();
 

--- a/src/hooks/useScrollToTop.ts
+++ b/src/hooks/useScrollToTop.ts
@@ -1,0 +1,11 @@
+import { useEffect } from "react";
+
+const useScrollToTop = () => {
+  useEffect(() => {
+    window.scrollTo({
+      top: 0,
+    });
+  }, []);
+};
+
+export default useScrollToTop;


### PR DESCRIPTION
리스트 페이지에서 디테일 페이지로 이동 시에 스크롤이 기억되어 디테일 페이지의 상단이 보이지 않는 문제 발생

window.scorllTo를 이용해 스크롤을 최상단으로 올려주는 useScrollToTop hook 작성 useScrollToTop 훅을 issueDetail/index.tsx에 배치하여 해결